### PR TITLE
Modify a type error

### DIFF
--- a/examples/sr/GEP_RNC_for_ML_with_UCI_Power_Plant_dataset.ipynb
+++ b/examples/sr/GEP_RNC_for_ML_with_UCI_Power_Plant_dataset.ipynb
@@ -778,7 +778,7 @@
     "    # That is, the predicated value for all the examples remains identical, which may happen in the evolution.\n",
     "    if isinstance(Yp, np.ndarray):\n",
     "        Q = np.hstack((np.reshape(Yp, (-1, 1)), np.ones((len(Yp), 1))))\n",
-    "        (individual.a, individual.b), residuals, _, _ = np.linalg.lstsq(Q, Y, rcond=None)   \n",
+    "        (individual.a, individual.b), residuals, _, _ = np.linalg.lstsq(Q, Y)   \n",
     "        # residuals is the sum of squared errors\n",
     "        if residuals.size > 0:\n",
     "            return residuals[0] / len(Y),   # MSE\n",


### PR DESCRIPTION
The parameter rcond must be a real number.This can cause a type error.Maybe it can be modified directly to the default parameters.