### PR TITLE
adapt the linker when dealing three or more genes in one chromosome

### DIFF
--- a/geppy/support/simplification.py
+++ b/geppy/support/simplification.py
@@ -85,6 +85,12 @@ def _simplify_kexpression(expr, symbolic_function_map):
 
 
 def simplify(genome, symbolic_function_map=None):
+    def link(linker, a):
+        a = list(a)
+        if len(a) == 2:
+            return linker(*a)
+        else:
+            return linker(a[0], link(linker, a[1:]))
     """
     Compile the primitive tree into a (possibly simplified) symbolic expression.
 
@@ -128,7 +134,7 @@ def simplify(genome, symbolic_function_map=None):
                 linker = symbolic_function_map[genome.linker.__name__]
             except:
                 linker = genome.linker
-            return sp.simplify(linker(*simplified_exprs))
+            return sp.simplify(link(linker, simplified_exprs))
     else:
         raise TypeError('Only an argument of type KExpression, Gene, and Chromosome is acceptable. The provided '
                         'genome type is {}.'.format(type(genome)))

--- a/geppy/tools/parser.py
+++ b/geppy/tools/parser.py
@@ -32,6 +32,13 @@ def _compile_gene(g, pset):
 
 
 def compile_(individual, pset):
+    def link(linker, a):
+        a = list(a)
+        if len(a) == 2:
+            return linker(*a)
+        else:
+            return linker(a[0], link(linker, a[1:]))
+
     """
     Compile the individual into a Python lambda expression.
 
@@ -47,7 +54,8 @@ def compile_(individual, pset):
             return fs[0]
         else:
             return lambda *x: tuple((f(*x) for f in fs))
-    return lambda *x: linker(*(f(*x) for f in fs))
+    # return lambda *x: linker(*(f(*x) for f in fs))
+    return lambda *x: link(linker, (f(*x) for f in fs))
 
 
 __all__ = ['compile_']


### PR DESCRIPTION
Generally the linker function links two genes and this is how the linking is implemented in geppy. However, when the number of genes was set to 3 or more, I encountered an error saying that extra parameters are passed to the linker function. I modified the linking mechanism so that it can links 3 or more genes.