### PR TITLE
Fix a bug that multiple genes with a None linker

### DIFF
--- a/geppy/core/entity.py
+++ b/geppy/core/entity.py
@@ -458,7 +458,7 @@ class Chromosome(list):
             is returned.
         """
         list.__init__(self, (gene_gen() for _ in range(n_genes)))
-        self._linker = linker
+        self._linker = linker if linker is not None else lambda *args:tuple(args)
 
     @classmethod
     def from_genes(cls, genes, linker=None):

--- a/geppy/core/entity.py
+++ b/geppy/core/entity.py
@@ -436,6 +436,10 @@ class GeneDc(Gene):
         return super().__repr__() + ', rnc_array=[' + ', '.join(str(num) for num in self.rnc_array) + ']'
 
 
+def _default_linker(*args): 
+    return tuple(args)
+
+
 class Chromosome(list):
     """
     Individual representation in gene expression programming (GEP), which may contain one or more genes. Note that in a
@@ -458,7 +462,7 @@ class Chromosome(list):
             is returned.
         """
         list.__init__(self, (gene_gen() for _ in range(n_genes)))
-        self._linker = linker if linker is not None else lambda *args:tuple(args)
+        self._linker = linker
 
     @classmethod
     def from_genes(cls, genes, linker=None):
@@ -530,6 +534,9 @@ class Chromosome(list):
             returns the value of the single gene for a single-gene (monogenic) chromosome or a tuple of values of all 
             genes for a multi-gene chromosome.
         """
+        # the default linker for a multi-gene chromosome
+        if self._linker is None and len(self) > 1:
+            return _default_linker
         return self._linker
 
     def __repr__(self):


### PR DESCRIPTION
## Problem
Thank you for providing us with an excellent **GEP** library, but I encountered the following problems during my development.
When there are **multiple** genes on a chromosome with `None` linker, the following two functions will run into problems

geppy->core->entity: `Chromosome.__str__`
```python
    def __str__(self):
        """
        Return the expressions in a human readable string.
        """
        if self.linker is not None:
            return '{0}(\n\t{1}\n)'.format(self.linker.__name__, ',\n\t'.join(str(g) for g in self))
        else:
            assert len(self) == 1
            return str(self[0])
```
The case where Linker is `None` is not handled here. When Linker is `None`, it will cause `AssertionError`

geppy->support->simplification: `simplify`
```python
def simplify(genome, symbolic_function_map=None):
    ...
    elif isinstance(genome, Chromosome):
        if len(genome) == 1:
            return _simplify_kexpression(genome[0].kexpression, symbolic_function_map)
        else:   # multigenic chromosome
            simplified_exprs = [_simplify_kexpression(
                g.kexpression, symbolic_function_map) for g in genome]
            # combine these sub-expressions into a single one with the linking function
            try:
                linker = symbolic_function_map[genome.linker.__name__]
            except:
                linker = genome.linker
            return sp.simplify(linker(*simplified_exprs))
    else:
        raise TypeError('Only an argument of type KExpression, Gene, and Chromosome is acceptable. The provided '
                        'genome type is {}.'.format(type(genome)))
```
Actually, `sp.simplify(linker(*simplified_exprs))` calls a 'NoneType' object on the grounds that Linker is `None`

---
## Solution
According to your comments
> If a linker is specified, then it must accept *n_genes* arguments, each produced by one gene. If the *linker* parameter is the default value ``None``, then for a monogenic chromosome, no linking is applied, while for a multigenic chromosome, the ``tuple`` function is used, i.e., a tuple of values of all genes is returned.

and the paper ***Ferreira, C. (2006). Gene expression programming: mathematical modeling by an artificial intelligence (Vol. 21). Springer.***. My simple solution is to set a default value for Linker such as a **Tuple Linker**
```python
tuple_linker = lambda *args:tuple(args)
```
After testing, this modification solves the above problems well.
